### PR TITLE
Downgrade ruby version dependency to >= 2.3

### DIFF
--- a/omniauth-teachfirst.gemspec
+++ b/omniauth-teachfirst.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.4'
+  spec.required_ruby_version = '>= 2.3'
 
   spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Rails 4.0 (Activesupport 4.0)  is not compatible with ruby >= 2.4